### PR TITLE
Removed color.base and reset skin.strings to empty 

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-	<addon id="script.skin.helper.colorpicker" name="Skin Helper Service ColorPicker" version="2.0.1" provider-name="sualfred,marcelveldt">
+	<addon id="script.skin.helper.colorpicker" name="Skin Helper Service ColorPicker" version="2.0.2" provider-name="sualfred,marcelveldt">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
 		<import addon="script.module.pil" version="1.1.7"/>

--- a/resources/lib/ColorPicker.py
+++ b/resources/lib/ColorPicker.py
@@ -179,17 +179,9 @@ class ColorPicker(xbmcgui.WindowXMLDialog):
             # load colors in the list
             self.load_colors_palette(self.active_palette)
 
-            # focus the current color
-            if self.current_window.getProperty("colorstring"):
-                self.current_window.setFocusId(3010)
-            else:
-                # no color setup so we just focus the colorslist
-                self.current_window.setFocusId(3110)
-                self.colors_list.selectItem(0)
-                self.current_window.setProperty("colorstring",
-                                                self.colors_list.getSelectedItem().getProperty("colorstring"))
-                self.current_window.setProperty("colorname",
-                                                self.colors_list.getSelectedItem().getLabel())
+            # focus the color list
+            self.current_window.setFocusId(3110)
+            self.colors_list.selectItem(0)
 
             # set opacity slider
             if self.current_window.getProperty("colorstring"):
@@ -236,17 +228,13 @@ class ColorPicker(xbmcgui.WindowXMLDialog):
 
         self.create_color_swatch_image(colorstring)
 
-        if self.skinstring and (not colorstring or colorstring == "None"):
-            xbmc.executebuiltin("Skin.SetString(%s.name, %s)" % (self.skinstring, ADDON.getLocalizedString(32013)))
-            xbmc.executebuiltin("Skin.SetString(%s, None)" % self.skinstring)
-            xbmc.executebuiltin("Skin.Reset(%s.base)" % self.skinstring)
+        if self.skinstring and (not colorstring or colorstring == ""):
+            xbmc.executebuiltin("Skin.Reset(%s.name)" % self.skinstring)
+            xbmc.executebuiltin("Skin.Reset(%s)" % self.skinstring)
 
         elif self.skinstring and colorstring:
             xbmc.executebuiltin("Skin.SetString(%s.name, %s)" % (self.skinstring, colorname))
             xbmc.executebuiltin("Skin.SetString(%s, %s)" % (self.skinstring, colorstring))
-
-            colorbase = "ff" + colorstring[2:]
-            xbmc.executebuiltin("Skin.SetString(%s.base, %s)" % (self.skinstring), colorbase)
 
         elif self.win_property:
             WINDOW.setProperty(self.win_property, colorstring)


### PR DESCRIPTION
@sualfred 

Color.base is no longer working and seems redundent and it was bloating the settings.xml 

The skin string color was set to none. It has been changed to a skin.reset. This reduces the number of string compares required in the skin.

Previouly
"!String.IsEmpty(Skin.String(FocusedSubMenuColor)) + !String.IsEqual(Skin.String(FocusedSubMenuColor),None)"

With the update
"!String.IsEmpty(Skin.String(FocusedSubMenuColor)) "


**Also;**
color.name in the settings.xml
My python skills rather limited and i was hoping i could come up with a solution. I have no idea how to fix this.

color.name may serve a purpose in the script window if a name is specified in the color xml, but is not required in the settings.xml it is unnessecary bloat.